### PR TITLE
Fedora Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM alpine:3.7
+FROM fedora:29
 MAINTAINER HomeOffice Devops <devops@digital.homeoffice.gov.uk>
 
 ENV CHISEL_VERSION=1.2.3
 
-RUN apk add --update --no-cache curl && \
+RUN dnf install curl -y && \
     curl -sL https://github.com/jpillora/chisel/releases/download/${CHISEL_VERSION}/chisel_linux_amd64.gz | gzip -d -c > /bin/chisel && \
     chmod +x /bin/chisel
-
-RUN adduser -S -u 1000 chisel
 
 USER 1000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ENV CHISEL_VERSION=1.2.3
 
 RUN dnf install curl -y && \
     curl -sL https://github.com/jpillora/chisel/releases/download/${CHISEL_VERSION}/chisel_linux_amd64.gz | gzip -d -c > /bin/chisel && \
-    chmod +x /bin/chisel
+    chmod +x /bin/chisel && \
+    groupadd -g 1000 chisel && \
+    useradd -g chisel -u 1000 chisel
 
 USER 1000
 


### PR DESCRIPTION
- updating using a fedora base image, due to resolver issues created by not using glibc