### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.17.3-alpine3.13 AS build
+FROM golang:1.20.1-alpine3.17 AS build
 WORKDIR /go/src/github.com/jpillora
 
 RUN apk update
 RUN apk add git
 
-ENV CHISEL_VERSION=v1.7.6
+ENV CHISEL_VERSION=v1.8.1
 ENV CGO_ENABLED 0
 
 RUN go install -ldflags "-X github.com/jpillora/chisel/share.BuildVersion=${CHISEL_VERSION}" github.com/jpillora/chisel@${CHISEL_VERSION}


### PR DESCRIPTION
Uplift base image to remove vulnerabilities and also uplift to the latest version of the chisel binary